### PR TITLE
Code Updates for Importing Auxiliar Enums + New Business Rules for Involved Companies and Indie Dashboards

### DIFF
--- a/airflow/dags/dag_extract_IGDB.py
+++ b/airflow/dags/dag_extract_IGDB.py
@@ -19,7 +19,7 @@ default_args = {
 dag = DAG(dag_id='dag_01_extract_IGDB',
           default_args=default_args,
           schedule_interval='0 5 * * *',
-          tags=['LANDING', 'IGDB', 'API', 'JSON', 'CSV']
+          tags=['LANDING', 'IGDB', 'API', 'JSON']
       )
 
 start_dag = DummyOperator(
@@ -38,19 +38,6 @@ task_extract = SparkSubmitOperator(
                           dag=dag
                       )
 
-task_import = SparkSubmitOperator(
-                          task_id='import_IGDB_Enums',
-                          conn_id='spark_local',
-                          jars='/usr/local/airflow/jars/aws-java-sdk-dynamodb-1.11.534.jar,\
-                                /usr/local/airflow/jars/aws-java-sdk-core-1.11.534.jar,\
-                                /usr/local/airflow/jars/aws-java-sdk-s3-1.11.534.jar,\
-                                /usr/local/airflow/jars/delta-core_2.12-2.0.0.jar,\
-                                /usr/local/airflow/jars/delta-storage-2.0.0.jar,\
-                                /usr/local/airflow/jars/hadoop-aws-3.2.2.jar'.replace(' ', ''),
-                          application='/usr/local/airflow/dags/spark_scripts/import_IGDB_Enums.py',
-                          dag=dag
-                      )
-
 dag_finish = DummyOperator(
                  task_id='dag_finish',
                  dag=dag
@@ -59,4 +46,4 @@ dag_finish = DummyOperator(
 
 # Pipeline definition
 
-start_dag >> [task_extract, task_import] >> dag_finish
+start_dag >> task_extract >> dag_finish

--- a/airflow/dags/dag_import_enums.py
+++ b/airflow/dags/dag_import_enums.py
@@ -1,0 +1,66 @@
+import os
+from airflow import DAG
+from datetime import datetime
+from airflow.models import Variable
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.contrib.operators.spark_submit_operator import SparkSubmitOperator
+
+os.environ["JAVA_HOME"] = Variable.get('JAVA_HOME')
+
+default_args = {
+    'owner': 'aulafia',
+    'start_date': datetime(2024, 5, 18)
+}
+
+
+
+# Pipeline definition
+
+dag = DAG(dag_id='dag_01_import_enums',
+          default_args=default_args,
+          schedule_interval='0 5 * * *',
+          tags=['LANDING', 'CSV']
+      )
+
+start_dag = DummyOperator(
+                task_id='start_dag',
+                dag=dag
+                )
+
+task_import_IGDB = SparkSubmitOperator(
+                          task_id='import_IGDB_Enums',
+                          conn_id='spark_local',
+                          jars='/usr/local/airflow/jars/aws-java-sdk-dynamodb-1.11.534.jar,\
+                                /usr/local/airflow/jars/aws-java-sdk-core-1.11.534.jar,\
+                                /usr/local/airflow/jars/aws-java-sdk-s3-1.11.534.jar,\
+                                /usr/local/airflow/jars/delta-core_2.12-2.0.0.jar,\
+                                /usr/local/airflow/jars/delta-storage-2.0.0.jar,\
+                                /usr/local/airflow/jars/hadoop-aws-3.2.2.jar'.replace(' ', ''),
+                          application='/usr/local/airflow/dags/spark_scripts/import_IGDB_Enums.py',
+                          dag=dag
+                      )
+
+task_import_Aux = SparkSubmitOperator(
+                          task_id='import_ISO_Enums',
+                          conn_id='spark_local',
+                          jars='/usr/local/airflow/jars/aws-java-sdk-dynamodb-1.11.534.jar,\
+                                /usr/local/airflow/jars/aws-java-sdk-core-1.11.534.jar,\
+                                /usr/local/airflow/jars/aws-java-sdk-s3-1.11.534.jar,\
+                                /usr/local/airflow/jars/delta-core_2.12-2.0.0.jar,\
+                                /usr/local/airflow/jars/delta-storage-2.0.0.jar,\
+                                /usr/local/airflow/jars/hadoop-aws-3.2.2.jar'.replace(' ', ''),
+                          application='/usr/local/airflow/dags/spark_scripts/import_Aux_Enums.py',
+                          dag=dag
+                      )
+
+
+
+dag_finish = DummyOperator(
+                 task_id='dag_finish',
+                 dag=dag
+                 )
+
+
+# Pipeline definition
+
+start_dag >> [task_import_IGDB, task_import_Aux] >> dag_finish

--- a/airflow/dags/dag_trust.py
+++ b/airflow/dags/dag_trust.py
@@ -207,6 +207,13 @@ task_configurations = {
             'source_tables': 'igdb.games igdb.player_perspectives',
         }
     },
+    'task_involved_companies_by_game': {
+        'task_id': 'create_involved_companies_by_game',
+        'specific_args': {
+            'table_name': 'involved_companies_by_game',
+            'source_tables': 'igdb.involved_companies igdb.companies igdb.games',
+        }
+    },
     'task_games': {
         'task_id': 'create_games',
         'specific_args': {
@@ -214,12 +221,20 @@ task_configurations = {
             'source_tables': 'igdb.games hltb.games igdb.covers',
         }
     },
+    'task_indie_games': {
+        'task_id': 'create_indie_games',
+        'specific_args': {
+            'table_name': 'indie_games',
+            'source_tables': 'trust.games_by_genre trust.games trust.games_by_platform trust.involved_companies_by_game',
+        }
+    }
 }
 
 # Define a lista de tasks e suas dependências
 tasks = [
-    [task_configurations['task_games_by_platform'], task_configurations['task_games_age_ratings'], task_configurations['task_game_modes_by_game'], task_configurations['task_games_by_franchise'], task_configurations['task_games_by_genre'], task_configurations['task_games_by_keyword'], task_configurations['task_games_by_themes'], task_configurations['task_language_supports_by_game'], task_configurations['task_player_perspectives_by_game']],
-    [task_configurations['task_games']]
+    [task_configurations['task_games_by_platform'], task_configurations['task_games_age_ratings'], task_configurations['task_game_modes_by_game'], task_configurations['task_games_by_franchise'], task_configurations['task_games_by_genre'], task_configurations['task_games_by_keyword'], task_configurations['task_games_by_themes'], task_configurations['task_language_supports_by_game'], task_configurations['task_player_perspectives_by_game'], task_configurations['task_involved_companies_by_game']],
+    [task_configurations['task_games']],
+    [task_configurations['task_indie_games']]
 ]
 
 

--- a/airflow/dags/spark_scripts/create_context_functions.py
+++ b/airflow/dags/spark_scripts/create_context_functions.py
@@ -129,6 +129,8 @@ def check_source_update(spark, configuration):
     # Obtém a data e hora da última criação do contexto para o endpoint
     df_target_control = get_target_control_table(spark, configuration["target_bucket_path"], configuration["schema"])
     last_target_run = get_last_run(df_target_control)
+
+    
     
     # Verifica se houve atualização na origem desde a última geração do contexto para o endpoint
     if not last_target_run or (last_source_update["Exec_time"] > last_target_run["Exec_time"]):
@@ -165,8 +167,8 @@ def sort_cols(df):
 
 
 # Obtém uma tabela de enumeração de um endpoint específico
-def get_enum_table(spark, endpoint, table_name):
-    delta_table_path = 's3a://raw/igdb_enums/' + endpoint + '/' + table_name + '/delta/'
+def get_enum_table(spark, enum_path, endpoint, table_name):
+    delta_table_path = 's3a://raw/' + enum_path + '/' + endpoint + '/' + table_name + '/delta/'
 
     try:
         df_delta = DeltaTable.forPath(spark, delta_table_path).toDF()
@@ -192,13 +194,14 @@ def get_raw_table(spark, endpoint):
 
 
 # Enriquece a tabela de contexto com uma tabela de enumeração
-def enrich_with_enum(spark, df, endpoint, enum_name):
+def enrich_with_enum(spark, df, enum_path, endpoint, enum_name):
     
     # Obtém a tabela de enumeração
-    df_enum = get_enum_table(spark, endpoint, enum_name)
+    df_enum = get_enum_table(spark, enum_path, endpoint, enum_name)
+
     # Se a tabela de enumeração existir
     if df_enum:
-        
+
         col_name = enum_name + '_name'
         # Enriquece a tabela de contexto com a descrição da enumeração
         df = (

--- a/airflow/dags/spark_scripts/create_trust.py
+++ b/airflow/dags/spark_scripts/create_trust.py
@@ -19,6 +19,7 @@ args = parser.parse_args()
 
 def main():
     # Obtém a sessão do Spark e as variáveis de configuração
+
     spark = tfn.create_spark_session()
     configuration = tfn.get_configuration(args)
 

--- a/airflow/dags/spark_scripts/create_trust_functions.py
+++ b/airflow/dags/spark_scripts/create_trust_functions.py
@@ -32,7 +32,7 @@ def get_configuration(args):
 
     # Cria uma lista que contém uma lista com o nome da API e o nome do endpoint para cada tabela de origem
     source_tables = [table.split('.') for table in args.source_tables.split()]
-       
+
     configuration = {
 
         "table_name": args.table_name,                   # Nome da tabela
@@ -116,12 +116,18 @@ def check_source_update(spark, configuration):
     # Obtém a data e hora da última criação da tablela trust
     df_target_control = get_target_control_table(spark, configuration["target_bucket_path"], configuration["schema"])
     last_target_run = get_last_run(df_target_control)
-        
+    
     # Obtém a data e hora da última atualização de cada tabela de origem
     last_source_updates = []
 
     for source_table in configuration['source_tables']:
-        df_source_control = get_source_control_table(spark, configuration["source_bucket_path"] + source_table[0] + '/' + source_table[1] + '/')
+        
+        if(source_table[0] == 'trust'):
+            source_control_path = 's3a://trust/' + source_table[1] + '/'
+        else:
+            source_control_path = configuration["source_bucket_path"] + source_table[0] + '/' + source_table[1] + '/'
+        
+        df_source_control = get_source_control_table(spark, source_control_path)
         last_source_updates.append(get_last_run(df_source_control))
     
     # Verifica se houve atualização nas origenes desde a última geração da tabela trust

--- a/airflow/dags/spark_scripts/extract_IGDB.py
+++ b/airflow/dags/spark_scripts/extract_IGDB.py
@@ -33,7 +33,7 @@ def get_configuration():
     configuration = {
         "api_name": 'igdb',
         "client_id": "nav10n96uf1vahn0sqiklmwuy331pz",
-        "authorization": "d1znlkl87wytdume5qqb6pu6u9cd35",
+        "authorization": "3hlrk0kjcnm1im7hxmwrgmaz03z77u",
         "url": 'https://api.igdb.com/v4/',
         
         "rate_limit": 1 / 4,        # Requisições por segundo (limitação da API)

--- a/airflow/dags/spark_scripts/import_Aux_Enums.py
+++ b/airflow/dags/spark_scripts/import_Aux_Enums.py
@@ -1,0 +1,226 @@
+# Define os imports necessários para a execução do código
+from pyspark.sql import SparkSession
+from pyspark.sql.types import *
+from pyspark.sql.utils import AnalysisException
+import pyspark.sql.functions as fn
+from datetime import datetime, timedelta, timezone
+from minio import Minio
+import time, os, re
+
+
+
+# Define a sessão do Spark com os jars necessários para conexão com o MINIO
+def create_spark_session():
+    return (SparkSession.builder
+            .config("spark.jars.packages", "io.delta:delta-core_2.12:2.0.0")
+            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+            .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+            .config("spark.hadoop.fs.s3a.endpoint", "http://minio:9000")
+            .config("spark.hadoop.fs.s3a.access.key", "aulafia")
+            .config("spark.hadoop.fs.s3a.secret.key", "aulafia@123")
+            .config("spark.hadoop.fs.s3a.path.style.access", True)
+            .config("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+            .config("spark.hadoop.fs.s3a.aws.credentials.provider", "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider")
+            .getOrCreate()
+            )
+
+
+
+# Define as variáveis parametrizáveis do script
+def get_configuration():
+    configuration = {
+        "api_name": "aux_enums",
+        
+        "file_name_pattern": r'aux_enum_([\w_]+)_([\w]+)\.csv',    # Padrão de nomenclatura para os arquivos
+                            
+        "source_bucket_name": 'landing-zone',                       # Nome do bucket de origem
+        "source_bucket_path": 's3a://landing-zone/aux_enums/',     # Caminho do bucket de origem
+        "target_bucket_path": 's3a://raw/aux_enums/',              # Caminho do bucket de destino
+
+        "schema": StructType([
+            StructField("Exec_date", StringType(), nullable=False),
+            StructField("Exec_time", LongType(), nullable=False),
+            StructField("Table_Rows", StringType(), nullable=False),
+            StructField("Total_duration", StringType(), nullable=False)
+        ])
+    }
+    return configuration
+
+
+
+# Define o cliente do Minio
+def get_minio_client():
+    return Minio("minio:9000", access_key="aulafia", secret_key="aulafia@123", secure=False)
+
+
+
+# Retorna a lista de objetos no bucket do Minio
+def list_objects(file_name_pattern, minio_client, bucket_name, prefix):
+
+    # Obtém a lista de objetos no bucket
+    objects = minio_client.list_objects(bucket_name, prefix=prefix, recursive=True)
+
+    # Filtra os objetos com base no padrão de nomenclatura
+    return [os.path.basename(obj.object_name) for obj in objects if re.match(file_name_pattern, os.path.basename(obj.object_name))]
+
+
+
+# Obtém a tabela de controle de atualizações (ou cria uma nova se ela não existir)
+def get_control_table(control_table_path, spark, schema):
+    try:
+        return spark.read.parquet(control_table_path)
+    except AnalysisException:
+        return spark.createDataFrame([], schema=schema)
+
+
+
+# Verifica se o arquivo foi modificado
+def check_file_modification(file_name, minio_client, df_control, bucket_name):
+    
+    # Obtém a data de modificação do arquivo no Minio
+    modified_time = int((minio_client.stat_object(bucket_name, file_name).last_modified).timestamp())
+    
+    # Obtém a última data de leitura registrada na tabela de controle
+    last_read_time = df_control.orderBy(fn.desc("Exec_time")).select("Exec_time").first()
+
+    if last_read_time:
+        # Se o arquivo foi modificado depois da última leitura, retorne True
+        return modified_time > last_read_time["Exec_time"]
+    
+    # Se o arquivo nunca foi lido, retorne True
+    else:
+        return True
+
+    
+
+
+# Atualiza a tabela delta raw do Enum
+def update_delta_table(spark, file_name, file_path, table_path):
+    df = spark.read.csv(file_path + file_name, header=True, sep=';')
+    
+    df.write.format("delta").mode("overwrite").save(table_path)
+
+    return df.count()
+
+
+
+# Atualiza a tabela de controle com a data e hora da importação
+def update_control_table(spark, schema, target_control_path, import_time, table_rows, formatted_time):
+    # Cria um DataFrame com o novo registro da tabela de controle
+    df_control = spark.createDataFrame([(
+                                            import_time.strftime("%Y-%m-%d %H:%M:%S"),
+                                            int(import_time.timestamp()),
+                                            table_rows,
+                                            formatted_time)], schema=schema)
+    
+    # Salva o novo registro da tabela de controle 
+    (df_control
+        .write
+        .format('parquet')
+        .mode('append')
+        .save(target_control_path)
+        )
+
+
+
+# Verifica se há arquivos para importação e executa o processo de importação
+def check_and_import_files(spark, minio_client, configuration, files_to_check, import_time):
+
+    imported_files = 0
+
+    for file_name in files_to_check:
+
+        print("Iniciando verificação de: ", file_name)
+
+        # Métrica de tempo de importação (início da verificação e importação do arquivo)
+        start_time_file = time.time()
+
+        # Obtém o nome da tabela de referência e o nome da tabela de enum, a partir do nome do arquivo
+        match = re.match(configuration["file_name_pattern"], file_name)
+        if match:
+            table_ref = match.group(1)
+            table_enum = match.group(2)
+
+            # Define o caminho da tabela de controle de atualizações
+            table_path = configuration["target_bucket_path"] + table_ref + '/' + table_enum
+    
+            # Obtém a tabela de controle de atualizações (ou cria uma nova se ela não existir)
+            df_control = get_control_table(table_path + '/control_table/', spark, configuration["schema"])
+
+            # Verifica se o arquivo foi modificado
+            if check_file_modification(configuration["api_name"] + '/' + file_name, minio_client, df_control, configuration["source_bucket_name"]):
+                
+                # Atualiza a tabela delta raw correspondente
+                table_rows = update_delta_table(spark, file_name, configuration["source_bucket_path"], table_path + '/delta/')
+                imported_files += 1
+
+                # Métrica de tempo de leitura (fim da leitura da data)
+                end_time_file = time.time()
+                execution_time_file = end_time_file - start_time_file
+
+                # Calcula o tempo de execução
+                hours, rem = divmod(execution_time_file, 3600)
+                minutes, seconds = divmod(rem, 60)
+
+                # Formata o tempo de execução
+                formatted_time = f"{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}"
+
+                # Atualiza a tabela de controle de atualizações
+                update_control_table(spark, configuration["schema"], table_path + '/control_table/', import_time, table_rows, formatted_time)
+                
+                print(f"O arquivo {file_name} foi modificado e a tabela delta raw correspondente foi atualizada.")
+            else:
+                print(f"O arquivo {file_name} não foi modificado.")
+        
+        else:
+            print(f"O arquivo {file_name} não está no padrão de nomenclatura esperado.")
+    
+    return imported_files
+
+
+
+def main():
+    # Obtém a sessão do Spark e as variáveis de configuração
+    spark = create_spark_session()
+    minio_client = get_minio_client()
+    configuration = get_configuration()
+
+    # Define o offset UTC para o Brasil (GMT-3)
+    time_offset = timezone(timedelta(hours=-3))
+
+    # Define a data e hora do início da importação para a tabela de controle de atualizações 
+    import_time = datetime.now(time_offset)
+
+    # Métrica de tempo de execução (início da importação)
+    start_time = time.time()
+
+    # Obtém a lista de objetos no bucket do Minio
+    files_to_check = list_objects(configuration["file_name_pattern"], minio_client, configuration["source_bucket_name"], configuration["api_name"])
+
+    print("Arquivos para verificar: ", files_to_check)
+    
+    # Verifica se há arquivos para verificação
+    if len(files_to_check) > 0:
+
+        # Verifica se há arquivos para importação e executa o processo de importação
+        imported_files = check_and_import_files(spark, minio_client, configuration, files_to_check, import_time)
+        print("Arquivos modificados e importados: ", imported_files)
+  
+    else:
+        print("Não há arquivos para importação")
+
+    # Métrica de tempo de execução (fim da importação)
+    end_time = time.time()
+    execution_time = end_time - start_time
+
+    # Calcula o tempo de execução
+    hours, rem = divmod(execution_time, 3600)
+    minutes, seconds = divmod(rem, 60)
+
+    # Formata o tempo de execução
+    formatted_time = f"{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}"
+
+    print(f"Processo finalizado em {formatted_time}.")   
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added a new Dag for handling Emun imports, for both IGDB and Auxiliar csvs; and added new business rules for context and trust tables to add columns for the Involved Comapnies and Indie Dashboards.